### PR TITLE
add game mode selection

### DIFF
--- a/web/backend/controllers/game-mode.ts
+++ b/web/backend/controllers/game-mode.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from "express";
+import { GameModeService } from "../services/game-mode-service";
+
+export const setGameMode =
+  (gameModeService: GameModeService) => (req: Request, res: Response) => {
+    console.info("Setting game mode to", req.body.gameMode);
+    gameModeService.setGameMode(req.body.gameMode);
+    res.status(200).send("Game mode set");
+  };

--- a/web/backend/index.ts
+++ b/web/backend/index.ts
@@ -2,15 +2,25 @@ import express, { Express } from "express";
 import dotenv from "dotenv";
 import ViteExpress from "vite-express";
 import { createSocket } from "./websocket/websocket";
+import { setGameMode } from "./controllers/game-mode";
+import { GAME_MODE } from "../types/game-modes";
+import { GameModeService } from "./services/game-mode-service";
 
 dotenv.config();
 ViteExpress.config({});
 
 const app: Express = express();
+
 const port = 3000;
+
+app.use(express.json());
 
 const server = ViteExpress.listen(app, port, () => {
   console.log(`[server]: Server is running at http://localhost:${port}`);
 });
 
-createSocket(server);
+const gameModeService = new GameModeService(GAME_MODE.SHORT_CIRCUIT);
+
+app.put("/game-mode", setGameMode(gameModeService));
+
+createSocket(server, gameModeService);

--- a/web/backend/services/game-mode-service.ts
+++ b/web/backend/services/game-mode-service.ts
@@ -1,0 +1,17 @@
+import { GAME_MODE } from '../../types/game-modes';
+
+export class GameModeService {
+  private gameMode: GAME_MODE;
+
+  constructor(initialGameMode: GAME_MODE) {
+    this.gameMode = initialGameMode;
+  }
+
+  public setGameMode(newGameMode: GAME_MODE) {
+    this.gameMode = newGameMode;
+  }
+
+  public getGameMode() {
+    return this.gameMode;
+  }
+}

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
   ShortCircuitState,
 } from "../../types/types.ts";
 import Calibrate from "./calibration/Calibrate.tsx";
+import GameModeSelect from "./game-mode/GameModeSelect.tsx";
 
 function App() {
   const socket = useMemo(
@@ -14,7 +15,7 @@ function App() {
       io({
         autoConnect: false,
       }),
-    [],
+    []
   );
 
   const [testDiscs, setTestDiscs] = useState([] as Disc[]);
@@ -60,6 +61,7 @@ function App() {
         />
       ) : (
         <>
+          <GameModeSelect />
           <BoardView discs={testDiscs} shortCircuit={shortCircuit} />
           {shortCircuit && (
             <div className="w-full grid grid-cols-12 h-32 bg-purple-500 border-t-8 border-amber-200">

--- a/web/frontend/src/api/game-mode.ts
+++ b/web/frontend/src/api/game-mode.ts
@@ -1,0 +1,11 @@
+import { GAME_MODE } from "../../../types/game-modes";
+
+export const setGameMode = async (gameMode: GAME_MODE) => {
+  await fetch("/game-mode", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ gameMode }),
+  });
+};

--- a/web/frontend/src/game-mode/GameModeSelect.tsx
+++ b/web/frontend/src/game-mode/GameModeSelect.tsx
@@ -1,0 +1,27 @@
+import { GAME_MODE } from "../../../types/game-modes";
+import { setGameMode } from "../api/game-mode";
+
+const GameModeSelect = () => {
+  return (
+    <div>
+      <button
+        className="w-full bg-green-600 text-white hover:bg-green-800 text-2xl p-4 text-center"
+        onClick={async () => {
+          await setGameMode(GAME_MODE.SHORT_CIRCUIT);
+        }}
+      >
+        SHORT CIRCUIT
+      </button>
+      <button
+        className="w-full bg-blue-600 text-white hover:bg-blue-800 text-2xl p-4 text-center"
+        onClick={async () => {
+          await setGameMode(GAME_MODE.ZONE_OF_CONTROL);
+        }}
+      >
+        ZONE OF CONTROL
+      </button>
+    </div>
+  );
+};
+
+export default GameModeSelect;

--- a/web/types/game-modes.ts
+++ b/web/types/game-modes.ts
@@ -1,0 +1,4 @@
+export enum GAME_MODE {
+    SHORT_CIRCUIT = "SHORT_CIRCUIT",
+    ZONE_OF_CONTROL = "ZONE_OF_CONTROL",
+}

--- a/web/types/types.ts
+++ b/web/types/types.ts
@@ -1,3 +1,5 @@
+import { GAME_MODE } from "./game-modes"
+
 export enum TeamColour {
     BLUE = "Blue",
     RED = "Red"
@@ -15,6 +17,7 @@ export type SendStateBody = Disc[]
 
 export type GameState = {
     discs: Disc[]
+    gameMode?: GAME_MODE
 }
 
 export type Distance = {


### PR DESCRIPTION
- Adds two buttons to the ui for the game mode we currently support and the one Alex is adding
- Clicking the buttons make an api request for the corresponding game mode
- Save the game mode in a game mode service which is injected into the websocket file so can be used in the future for setting disc state