### PR TITLE
Transform stage coordinates to camera coordinates

### DIFF
--- a/camera/shuffleboard/sockets.py
+++ b/camera/shuffleboard/sockets.py
@@ -22,6 +22,16 @@ async def send_state_periodically():
 
     def update_calibration_coordinates(coordinates):
         global board_coordinates
+
+        # TODO: We need to add margins to these coordinates before saving them.
+        #
+        # Detections are designed to work when > 0.5 of the disc is visible in the image.
+        # For the surface midpoint, we need a negative margin to ensure the disc has fully
+        # crossed the line (since detection works with only > 0.5 of disc visible).
+        # For the other three edges, we need positive margins to detect discs that are
+        # partially on the edge of the surface (where only ~half the disc width is visible).
+        #
+        # These margins will be dependent on the shot dimensions.
         board_coordinates = coordinates
 
         logger.info(f'New calibration coordinates: {coordinates}')

--- a/web/frontend/src/calibration/Calibrate.tsx
+++ b/web/frontend/src/calibration/Calibrate.tsx
@@ -31,7 +31,7 @@ function Calibrate({ image, socket, onComplete }: CalibrateProps) {
   const [reactImage] = useImage("data:image/jpeg;base64," + image);
   useEffect(() => {
     console.log(currentCorner);
-  }, [currentCorner, width, height]);
+  }, [currentCorner]);
 
   const transformStageCoordinatesToCameraCoordinates = (stageCoordinates: Coordinate[]): Coordinate[] => 
     stageCoordinates.map(([x, y]) => [

--- a/web/frontend/src/calibration/Calibrate.tsx
+++ b/web/frontend/src/calibration/Calibrate.tsx
@@ -31,10 +31,23 @@ function Calibrate({ image, socket, onComplete }: CalibrateProps) {
   const [reactImage] = useImage("data:image/jpeg;base64," + image);
   useEffect(() => {
     console.log(currentCorner);
-  }, [currentCorner]);
+  }, [currentCorner, width, height]);
 
-  const submitCalibration = async (allCorners: Coordinate[]) => {
-    socket.emit("send-calibration-coordinates", allCorners);
+  const transformStageCoordinatesToCameraCoordinates = (stageCoordinates: Coordinate[]): Coordinate[] => 
+    stageCoordinates.map(([x, y]) => [
+      x * (CAMERA_WIDTH / width),
+      y * (CAMERA_HEIGHT / height)
+    ]);
+
+  const submitCalibration = async (stageCoordinates: Coordinate[]) => {
+    if (stageCoordinates.length !== 4) {
+      throw new Error("4 corner coordinates required for calibration.");
+    }
+
+    const cameraCoordinates = transformStageCoordinatesToCameraCoordinates(stageCoordinates);
+
+    socket.emit("send-calibration-coordinates", cameraCoordinates);
+
     onComplete();
   };
 

--- a/web/frontend/src/calibration/Calibrate.tsx
+++ b/web/frontend/src/calibration/Calibrate.tsx
@@ -25,8 +25,12 @@ function Calibrate({ image, socket, onComplete }: CalibrateProps) {
   const currentStep = corners.length;
   const [currentCorner, setCurrentCorner] = useState<Coordinate>([0, 0]);
   const mouseDown = useRef(false);
+
   const width = window.innerWidth;
   const height = (CAMERA_HEIGHT / CAMERA_WIDTH) * width;
+
+  const scaleX = CAMERA_WIDTH / width
+  const scaleY = CAMERA_HEIGHT / height
 
   const [reactImage] = useImage("data:image/jpeg;base64," + image);
   useEffect(() => {
@@ -40,8 +44,8 @@ function Calibrate({ image, socket, onComplete }: CalibrateProps) {
    */
   const transformStageCoordinatesToCameraCoordinates = (stageCoordinates: Coordinate[]): Coordinate[] => 
     stageCoordinates.map(([x, y]) => [
-      x * (CAMERA_WIDTH / width),
-      y * (CAMERA_HEIGHT / height)
+      x * scaleX,
+      y * scaleY
     ]);
 
   const submitCalibration = async (stageCoordinates: Coordinate[]) => {

--- a/web/frontend/src/calibration/Calibrate.tsx
+++ b/web/frontend/src/calibration/Calibrate.tsx
@@ -33,6 +33,11 @@ function Calibrate({ image, socket, onComplete }: CalibrateProps) {
     console.log(currentCorner);
   }, [currentCorner]);
 
+  /**
+   * Transform coordinates from stage (display) space to camera space.
+   * Since the stage is scaled to fit the window width while maintaining aspect ratio,
+   * we need to scale the coordinates back to match the actual camera resolution.
+   */
   const transformStageCoordinatesToCameraCoordinates = (stageCoordinates: Coordinate[]): Coordinate[] => 
     stageCoordinates.map(([x, y]) => [
       x * (CAMERA_WIDTH / width),


### PR DESCRIPTION
The frontend appears to be sending through calibration coordinates relative to the size of the image being rendered in the 'Stage' element. This is leading to incorrect calibration coordinates being used by the camera service, despite the user clicking the corners accurately in the rendered image on the frontend.

This PR adds a transformation function to the frontend to ensure these are accurate when working with the original image captured by the camera (vs the variable size image being rendered on the frontend).

Other PRs (#6 #7 #8) have added a "visualise calibration coordinates" function to visualise the coordinates being passed to the camera service, this has been used for debugging purposes and its outputs are shown in the screenshots below.

## Screenshots

**Before PR:**

![debug_calibrated_coordinates](https://github.com/user-attachments/assets/f23b0275-c49b-4c38-9d50-26de38c6716b)

**After PR:**

![debug_calibrated_coordinates](https://github.com/user-attachments/assets/958cb549-1f3a-4c45-be97-3bac9024d518)
